### PR TITLE
typo fix for Patrick Bently title

### DIFF
--- a/_data/senior_leadership.yml
+++ b/_data/senior_leadership.yml
@@ -89,7 +89,7 @@
   github: opensavannah
   linkedin:
 - name: Patrick Bentley
-  title: Econonic and Workforce Development Lead
+  title: Economic and Workforce Development Lead
   headshot: pbentley.png
   bio: >-
     Patrick is the Project Manger of Emerging Industries for the Savannah


### PR DESCRIPTION
My name is Bonnie and I am the co-host of Hack For LA Downtown Los Angeles's meetup.  I am doing a survey of leadership roles across all the brigades.  While I was there I noticed a typo on your website on your Patrick's title.  Its currently listed as "Econonic and Workforce Development Lead" instead of "Economic and Workforce Development Lead" . This PR request fixes that.